### PR TITLE
Fix build for epa-ng recipe (on bioconda-docker at least)

### DIFF
--- a/recipes/epa-ng/build.sh
+++ b/recipes/epa-ng/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Make m4 accessible to bison
+# https://github.com/conda-forge/bison-feedstock/issues/7#issuecomment-431602144
+export M4=m4
+
 make 
 
 mkdir -p $PREFIX/bin

--- a/recipes/epa-ng/conda_build_config.yaml
+++ b/recipes/epa-ng/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/epa-ng/meta.yaml
+++ b/recipes/epa-ng/meta.yaml
@@ -11,10 +11,11 @@ source:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - libtool
     - flex
     - bison
+    - m4
     - cmake==3.11
     - automake
     - autoconf


### PR DESCRIPTION
Change compiler to C++, use latest compilers by opting into conda build 3 via `conda_build_config.yaml` and adds m4 as a build dep.